### PR TITLE
Add lint and spellcheck CI

### DIFF
--- a/.github/spelling/excludes.txt
+++ b/.github/spelling/excludes.txt
@@ -1,0 +1,2 @@
+# exclude JavaScript built files
+node_modules/

--- a/.github/spelling/expect.txt
+++ b/.github/spelling/expect.txt
@@ -1,0 +1,6 @@
+TempVoice
+Jevenchy
+Discord
+discordjs
+multilingual
+DISCORD_TOKEN

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,27 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [ main ]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+      - run: npm ci
+      - run: npm run lint
+  spellcheck:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+      - uses: check-spelling/check-spelling@v0
+        with:
+          config: .github/spelling

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,15 @@
+export default [
+  {
+    files: ['**/*.js'],
+    ignores: ['node_modules/**'],
+    languageOptions: {
+      ecmaVersion: 'latest',
+      sourceType: 'module'
+    },
+    linterOptions: {
+      reportUnusedDisableDirectives: true
+    },
+    rules: {
+    }
+  }
+]

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "type": "module",
   "main": "src/index.js",
   "scripts": {
-    "start": "node src/index.js"
+    "start": "node src/index.js",
+    "lint": "eslint ."
   },
   "author": "Jevenchy",
   "license": "MIT",
@@ -34,5 +35,8 @@
     "discord.js": "^14.14.1",
     "dotenv": "^16.4.5",
     "moment": "^2.30.1"
+  },
+  "devDependencies": {
+    "eslint": "^9.31.0"
   }
 }


### PR DESCRIPTION
## Summary
- add ESLint configuration with lint script
- run ESLint and spellcheck in GitHub Actions
- add spelling dictionary files

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_687f6126a91c832ea7780d4d80c6f849